### PR TITLE
Install dependencies, clean up after integration tests

### DIFF
--- a/bin/npo_integration_tests
+++ b/bin/npo_integration_tests
@@ -79,7 +79,8 @@ def check_on_backend():
     clip = backend.get("crid://pyapi/clip/1")
     assert clip
     clip = mediaupdate.CreateFromDocument(clip)
-    #assert clip.mid == "WO_VPRO_1425989"
+    # assert clip.mid == "WO_VPRO_1425989"
+    print(clip.title[0].value())
     assert clip.title[0].value().endswith(time_str)
 
 
@@ -95,10 +96,21 @@ def check_frontend_media():
     assert t > (time.time() - latency), "should be published in 10 minutes " + title + " < " + str(time.time())
 
 
+def remove_clip():
+    backend.delete_from("crid://pyapi/clip/1")
+
+
+def remove_segment():
+    backend.delete_from("crid://pyapi/segment/2")
+
 post_to_backend()
 time.sleep(5)
 check_on_backend()
 check_frontend_media()
+
+# This doesn't work without the right credentials. How do we solve this for integration tests?
+remove_clip()
+remove_segment()
 
 
 

--- a/npoapi/npoapi.py
+++ b/npoapi/npoapi.py
@@ -2,11 +2,8 @@ import base64
 import hashlib
 import hmac
 import json
-import os
 import urllib.request
 from email import utils
-import sys
-import codecs
 
 from npoapi.base import NpoApiBase
 
@@ -131,8 +128,4 @@ class NpoApi(NpoApiBase):
         req.add_header("Accept", accept if accept else self._accept)
         self.logger.debug("headers: " + str(req.headers))
         return self.get_response(req, url)
-
-
-
-
 

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-from distutils.core import setup
+from setuptools import setup
 
 __version__ = None
 exec(open('npoapi/_version.py', "rt").read())
@@ -7,7 +7,8 @@ exec(open('npoapi/_version.py', "rt").read())
 setup(
     name='NPO API',
     version=__version__,
-    packages=['npoapi', 'npoapi.xml' ],
+    packages=['npoapi', 'npoapi.xml'],
+    install_requires=['pytz', 'pyxb'],
     scripts=[
         'bin/npo_media_get',
         'bin/npo_media_search',


### PR DESCRIPTION
Using setuptools, we can install the required dependencies.

Currently, the integration tests create objects that linger after we're done. They should be cleaned up right?